### PR TITLE
Fix line break is inserted on enter

### DIFF
--- a/VS-QuickNavigation/ToolWindow/QuickFile/QuickFileToolWindowControl.xaml.cs
+++ b/VS-QuickNavigation/ToolWindow/QuickFile/QuickFileToolWindowControl.xaml.cs
@@ -115,6 +115,7 @@ namespace VS_QuickNavigation
 				if (e.Key == System.Windows.Input.Key.Return)
 				{
 					OpenCurrentSelection();
+					e.Handled = true;
 				}
 				else if (e.Key == System.Windows.Input.Key.Escape)
 				{
@@ -135,6 +136,7 @@ namespace VS_QuickNavigation
 				if (e.Key == System.Windows.Input.Key.Return)
 				{
 					OpenCurrentSelection();
+					e.Handled = true;
 				}
 				else if (e.Key == System.Windows.Input.Key.Escape)
 				{

--- a/VS-QuickNavigation/ToolWindow/QuickMethod/QuickMethodToolWindowControl.xaml.cs
+++ b/VS-QuickNavigation/ToolWindow/QuickMethod/QuickMethodToolWindowControl.xaml.cs
@@ -109,6 +109,7 @@ namespace VS_QuickNavigation
 				{
 					mQuickMethodToolWindow.Close();
 					OpenCurrentSelection();
+					e.Handled = true;
 				}
 				else if (e.Key == System.Windows.Input.Key.Escape)
 				{
@@ -130,6 +131,7 @@ namespace VS_QuickNavigation
 				{
 					OpenCurrentSelection();
 					mQuickMethodToolWindow.Close();
+					e.Handled = true;
 				}
 				else if (e.Key == System.Windows.Input.Key.Escape)
 				{


### PR DESCRIPTION
On the key down event a file was opened and after that the key up event inserted a line break in that file. This pull request fixes that behavior.